### PR TITLE
bug: --no-em will now output patterns

### DIFF
--- a/src/peng.cpp
+++ b/src/peng.cpp
@@ -357,6 +357,8 @@ void Peng::process(PengParameters& params, std::vector<IUPACPattern*>& best_iupa
         em_optimize_pwms(unoptimized_iupac_patterns, base_pattern,
         				 params.em_saturation_factor, params.em_min_threshold, params.em_max_iterations,
                          pattern_bg_probs, optimized_patterns);
+      } else {
+        optimized_patterns = std::move(unoptimized_iupac_patterns);
       }
 
       if(params.use_merging) {
@@ -374,6 +376,10 @@ void Peng::process(PengParameters& params, std::vector<IUPACPattern*>& best_iupa
         optimized_patterns[i]->set_optimization_bg_model_order(background);
         best_iupac_patterns.push_back(optimized_patterns[i]);
       }
+    }
+
+    for(IUPACPattern* p : unoptimized_iupac_patterns){
+      delete p;
     }
 
     delete base_pattern;


### PR DESCRIPTION
@meiermark, can you quickly have a look if this change will work? 

I don't yet understand where the patterns in `unoptimized_iupac_patterns` are deallocated. `em_optimize_pwms` creates new objects for the optimized pwms, after that `unoptimized_iupac_patterns` does not seem to be used. Am I missing something?

https://github.com/soedinglab/PEnG-motif/blob/4e8b3801ed17be5be55eb97c74953e8b6b4b27d5/src/peng.cpp#L357-L359
