### PR TITLE
feature: add option to run shoot peng without pwm scoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - 3.3
+    - 3.5
 sudo: required
 dist: trusty
 
@@ -17,7 +17,8 @@ script:
   - mkdir build
   - cd build
   - cmake .. && make
-  - ./bin/peng_motif ../data/MafK_100seqs.fasta -w 6
+  - export PATH="$PATH:$PWD/bin"
+  - python ../scripts/shoot_peng.py ../data/MafK_100seqs.fasta -w 6 --no-scoring -o test.out
 
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ It is intended to be a fast prefilter for a future release of [BaMMmotif](https:
 
 ## Requirements
 
-To compile from source, you will need:
+To compile and run PEnG-motif, you need
  * [CMake](http://cmake.org/) 2.8.12 or later
- * C++ compiler (support for C++14)
+ * a recent C++ compiler (support for C++14)
+
+### Optional requirements for running the scripts
+
+  * python>=3.5
+  * numpy
 
 
 ## Installation
@@ -22,7 +27,7 @@ To compile from source, you will need:
 ### Cloning from GIT
 If you want to compile the most recent version, simply clone the git repository.
 
-	git clone git@github.com:soedinglab/PEnG-motif.git
+	git clone https://github.com/soedinglab/PEnG-motif.git
 	cd PEnG-motif
 
 ### Compilation
@@ -53,28 +58,16 @@ For performing a search for overrepresented motives in a set of DNA sequences ru
   peng_motif -w 10 --pseudo-counts 10 -b 0.4 -a 1E4 -o output.meme input.fasta
 
 You can get a detailed list of options for peng_motif by calling it without arguments.
-This script is a wrapper for PEnG that will rerank the models using binaries and scripts from BaMM.
 
 ## Future
 With a future release of [BaMMmotif](https://github.com/soedinglab/BaMMmotif) we can rerank
 the models of PEnG with a proper score. For this purpose the python script shoot_peng.py
-exists.
+exists. This script is a wrapper for PEnG that will rerank the models using binaries and scripts from BaMM.
 
 
 ## License
 
 The PEnG-motif is distributed under the GPL-3.0 License.
-
-
-## Notes
-
-We are very grateful for bug reports!
-Please contact us at soeding@mpibpc.mpg.de
-
-
-## Links
-
-* [soeding lab](http://www.mpibpc.mpg.de/soeding)
 
 
 ## Acknowledgements

--- a/scripts/shoot_peng.py
+++ b/scripts/shoot_peng.py
@@ -79,7 +79,7 @@ def main():
     parser.add_argument('--silent', action='store_true',
                         help='capture and suppress output on stdout')
     parser.add_argument('--no-scoring', action='store_true', dest='no_scoring',
-                        help='skip the calculation of the zoops score')
+                        help='skip the calculation of the pwm performance score')
 
     args = parser.parse_args()
 
@@ -214,7 +214,7 @@ def run_peng(args, output_directory, run_scoring):
     else:
         patterns = peng_data["patterns"]
         for p in patterns:
-            p["zoops_score"] = "?"
+            p["zoops_score"] = float('nan')
 
     if args.meme_output_file:
         write_meme(peng_data, args.meme_output_file)

--- a/scripts/shoot_peng.py
+++ b/scripts/shoot_peng.py
@@ -24,16 +24,9 @@ def check_executable_presence(executable_name):
     return True
 
 
-RSCRIPT = "evaluateBaMM.R" #"plotAUSFC_benchmark_fdrtool.R" #"plotAUSFC_rank.R"
+RSCRIPT = "evaluateBaMM.R"
 PENG = "peng_motif"
 FDR = "FDR"
-
-ready = True
-for tool in RSCRIPT, PENG, FDR:
-    if not check_executable_presence(tool):
-        ready = False
-if not ready:
-    sys.exit(10)
 
 
 def main():
@@ -85,23 +78,36 @@ def main():
                         help='number of threads to be used for parallelization')
     parser.add_argument('--silent', action='store_true',
                         help='capture and suppress output on stdout')
+    parser.add_argument('--no-scoring', action='store_true', dest='no_scoring',
+                        help='skip the calculation of the zoops score')
 
     args = parser.parse_args()
 
     if args.meme_output_file is None and args.json_output_file is None:
         print("Warning: you did not define an output file (options -o or -j). Stopping here.", file=sys.stderr)
-        sys.exit(0)
+        sys.exit(1)
+
+    required_tools = [PENG]
+    if not args.no_scoring:
+        required_tools += [RSCRIPT, FDR]
+
+    ready = True
+    for tool in required_tools:
+        if not check_executable_presence(tool):
+            ready = False
+    if not ready:
+        sys.exit(10)
 
     output_directory = args.output_directory
     if args.output_directory is None:
         # work in tmp directory
         with tempfile.TemporaryDirectory() as output_directory:
-            run_peng(args, output_directory)
+            run_peng(args, output_directory, not args.no_scoring)
     else:
         if not os.path.exists(output_directory):
             # make user defined directory if not exist
             os.makedirs(output_directory)
-        run_peng(args, output_directory)
+        run_peng(args, output_directory, not args.no_scoring)
 
 
 def build_peng_command(args, protected_fasta_file, peng_output_file, peng_json_file):
@@ -148,7 +154,7 @@ def build_fdr_command(args, protected_fasta_file, peng_output_file, output_direc
     return command
 
 
-def run_peng(args, output_directory):
+def run_peng(args, output_directory, run_scoring):
     # FDR takes the prefix from the input fasta-file
     filename, extension = os.path.splitext(args.fasta_file)
     prefix = os.path.basename(filename)
@@ -170,42 +176,45 @@ def run_peng(args, output_directory):
     peng_command_line = build_peng_command(args, protected_fasta_file, peng_output_file, peng_json_file)
     subprocess.run(peng_command_line, check=True, stdout=stdout)
 
-    # run FDR
-    fdr_command_line = build_fdr_command(args, protected_fasta_file, peng_output_file, output_directory)
-    subprocess.run(fdr_command_line, check=True, stdout=stdout)
-    r_output_file = os.path.join(output_directory, prefix + ".bmscore")
-    subprocess.run([RSCRIPT, os.path.abspath(output_directory), prefix], check=True, stdout=stdout)
-
-    # run R script
-    zoops_scores = dict()
-#    occs = dict()
-    with open(r_output_file) as fh:
-        for line in fh:
-            if line.startswith("prefix"):
-                continue
-            prefix, motif_number, zoops_rank_score, auc5_score, auprc_score = line.split()
-            motif_number = int(motif_number)
-
-            try:
-                # note here ausfc score is used for reranking, instead of fract_occ
-                zoops_scores[motif_number] = float(zoops_rank_score)
-#                occs[motif_number] = float(fract_occ)
-            except:
-                zoops_scores[motif_number] = np.nan
-
     with open(peng_json_file) as fh:
         peng_data = json.load(fh)
 
-    # update information
-    patterns = peng_data["patterns"]
-    for idx, p in enumerate(patterns):
-        if idx + 1 in zoops_scores:
-            p["zoops_score"] = zoops_scores[idx + 1]
-            print("{} {}".format(p["iupac_motif"], p["zoops_score"]))
-        else:
-            p["zoops_score"] = np.nan
+    if run_scoring:
+        # run FDR
+        fdr_command_line = build_fdr_command(args, protected_fasta_file, peng_output_file, output_directory)
+        subprocess.run(fdr_command_line, check=True, stdout=stdout)
+        r_output_file = os.path.join(output_directory, prefix + ".bmscore")
+        subprocess.run([RSCRIPT, os.path.abspath(output_directory), prefix], check=True, stdout=stdout)
 
-    peng_data["patterns"] = sorted(peng_data["patterns"], key=lambda k: k['zoops_score'], reverse=True)
+        # run R script
+        zoops_scores = dict()
+        with open(r_output_file) as fh:
+            for line in fh:
+                if line.startswith("prefix"):
+                    continue
+                prefix, motif_number, zoops_rank_score, auc5_score, auprc_score, *_ = line.split()
+                motif_number = int(motif_number)
+
+                try:
+                    # note here ausfc score is used for reranking, instead of fract_occ
+                    zoops_scores[motif_number] = float(zoops_rank_score)
+                except:
+                    zoops_scores[motif_number] = np.nan
+
+        # update information
+        patterns = peng_data["patterns"]
+        for idx, p in enumerate(patterns):
+            if idx + 1 in zoops_scores:
+                p["zoops_score"] = zoops_scores[idx + 1]
+                print("{} {}".format(p["iupac_motif"], p["zoops_score"]))
+            else:
+                p["zoops_score"] = np.nan
+
+        peng_data["patterns"] = sorted(peng_data["patterns"], key=lambda k: k['zoops_score'], reverse=True)
+    else:
+        patterns = peng_data["patterns"]
+        for p in patterns:
+            p["zoops_score"] = "?"
 
     if args.meme_output_file:
         write_meme(peng_data, args.meme_output_file)


### PR DESCRIPTION
* adds new option `--no-scoring` to shootpeng that skips the zoops score evalutation
* shootpeng is now able to parse `.bmfiles` correctly.

Does that work for you @AnjaSophieKiesel ?